### PR TITLE
Duplicate htmlmin

### DIFF
--- a/addressbook/Gruntfile.js
+++ b/addressbook/Gruntfile.js
@@ -379,7 +379,6 @@ module.exports = function (grunt) {
         'copy',
         'rev',
         'usemin',
-        'htmlmin',
         'manifest',
         'amendIndexFile'
     ]);

--- a/demoapp/Gruntfile.js
+++ b/demoapp/Gruntfile.js
@@ -379,7 +379,6 @@ module.exports = function (grunt) {
         'copy',
         'rev',
         'usemin',
-        'htmlmin',
         'manifest',
         'amendIndexFile'
     ]);


### PR DESCRIPTION
The duplicate 'htmlmin' will create the index.html file again with the wrong paths to .js and .css files.
